### PR TITLE
add source map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "index.js",
   "dependencies": {
     "javascript-obfuscator": "^0.7.0-dev.3",
+    "multi-stage-sourcemap": "^0.2.1",
     "multimatch": "^2.0.0",
     "webpack-core": "^0.6.8"
   },


### PR DESCRIPTION
I added source map support (which fixes #5) by following the example of the uglifyjs plugin and using [multi-stage-sourcemap](https://github.com/azu/multi-stage-sourcemap) for re-mapping the sourcemap generated by the obfuscator to the one generated by webpack.
I tested it in a fairly complex project and it seems to work.